### PR TITLE
Feature: load several plugins in a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,19 @@ Fields:
 - `tag`: Optional GitHub tag
 - `skip_auto_update` : Disable automatic updates (default: false)
 - `source`: List of plugin source script files loaded by tmux
-  
+
+### Multiple Plugins per File
+
+One plugin per file is the recommended approach. However, you can also group multiple plugins in a single YAML file using a list:
+
+```yaml
+# ~/.config/tmux/coffee/plugins/my-plugins.yaml
+- url: "tmux-plugins/tmux-sensible"
+- url: "tmux-plugins/tmux-resurrect"
+```
+
+Files are loaded in alphabetical order, so plugin sourcing order is determined first by filename, then by position within the file.
+
 ## Usage
 
 ### CLI Commands

--- a/core/plugin_installer.py
+++ b/core/plugin_installer.py
@@ -225,6 +225,20 @@ class PluginInstaller:
 
             lock_data["plugins"].append(plugin_data)
 
+        # Reorder to match the config order
+        plugin_names = [p["name"] for p in self.plugins_config]
+        plugins_by_name: dict[str, dict[str, Any]] = {
+            p["name"]: p for p in lock_data["plugins"]
+        }
+
+        ordered: list[dict[str, Any]] = []
+        for name in plugin_names:
+            if name in plugins_by_name:
+                ordered.append(plugins_by_name.pop(name))
+
+        ordered.extend(plugins_by_name.values())
+
+        lock_data["plugins"] = ordered
         lfm.write_lock_file(lock_data)
 
     def _discover_tmux_sources(self, plugin_path: str) -> list[str]:

--- a/core/plugin_loader.py
+++ b/core/plugin_loader.py
@@ -17,7 +17,7 @@ class PluginLoader:
                 f"Plugin directory not found: {self.coffee_plugins_list_dir}"
             )
 
-        for filename in os.listdir(self.coffee_plugins_list_dir):
+        for filename in sorted(os.listdir(self.coffee_plugins_list_dir)):
             if not filename.endswith((".yaml", ".yml")):
                 continue
 
@@ -37,9 +37,9 @@ class PluginLoader:
                         raise ValueError(
                             f"Each item in plugin list must be a mapping in {file_path}"
                         )
-                    self._process_plugin_entry(entry, file_path, plugin_urls, plugins)
+                    plugins.append(self._process_plugin_entry(entry, file_path, plugin_urls))
             elif isinstance(raw, dict):
-                self._process_plugin_entry(raw, file_path, plugin_urls, plugins)
+                plugins.append(self._process_plugin_entry(raw, file_path, plugin_urls))
             else:
                 raise ValueError(f"Invalid plugin config in {file_path}")
 
@@ -50,8 +50,7 @@ class PluginLoader:
         raw: dict[str, Any],
         file_path: str,
         plugin_urls: set[str],
-        plugins: list[dict[str, Any]],
-    ) -> None:
+    ) -> dict[str, Any]:
         plugin = self._build_plugin_config(raw)
 
         if not self._is_valid_plugin(plugin):
@@ -66,7 +65,7 @@ class PluginLoader:
 
         plugin_urls.add(normalized_url)
         plugin["url"] = normalized_url
-        plugins.append(plugin)
+        return plugin
 
     def _build_plugin_config(self, data: dict[str, Any]) -> dict[str, Any]:
         url = (data.get("url") or "").strip()

--- a/core/plugin_loader.py
+++ b/core/plugin_loader.py
@@ -31,21 +31,15 @@ class PluginLoader:
 
             if isinstance(raw, list):
                 if len(raw) == 0:
-                    raise ValueError(
-                        f"Plugin list must not be empty in {file_path}"
-                    )
+                    raise ValueError(f"Plugin list must not be empty in {file_path}")
                 for entry in raw:
                     if not isinstance(entry, dict):
                         raise ValueError(
                             f"Each item in plugin list must be a mapping in {file_path}"
                         )
-                    self._process_plugin_entry(
-                        entry, file_path, plugin_urls, plugins
-                    )
+                    self._process_plugin_entry(entry, file_path, plugin_urls, plugins)
             elif isinstance(raw, dict):
-                self._process_plugin_entry(
-                    raw, file_path, plugin_urls, plugins
-                )
+                self._process_plugin_entry(raw, file_path, plugin_urls, plugins)
             else:
                 raise ValueError(f"Invalid plugin config in {file_path}")
 

--- a/core/plugin_loader.py
+++ b/core/plugin_loader.py
@@ -37,7 +37,9 @@ class PluginLoader:
                         raise ValueError(
                             f"Each item in plugin list must be a mapping in {file_path}"
                         )
-                    plugins.append(self._process_plugin_entry(entry, file_path, plugin_urls))
+                    plugins.append(
+                        self._process_plugin_entry(entry, file_path, plugin_urls)
+                    )
             elif isinstance(raw, dict):
                 plugins.append(self._process_plugin_entry(raw, file_path, plugin_urls))
             else:

--- a/core/plugin_loader.py
+++ b/core/plugin_loader.py
@@ -24,25 +24,55 @@ class PluginLoader:
             file_path = os.path.join(self.coffee_plugins_list_dir, filename)
 
             with open(file_path, "r", encoding="utf-8") as f:
-                raw = yaml.safe_load(f) or {}
+                raw = yaml.safe_load(f)
 
-            plugin = self._build_plugin_config(raw)
+            if raw is None:
+                raw = {}
 
-            if not self._is_valid_plugin(plugin):
+            if isinstance(raw, list):
+                if len(raw) == 0:
+                    raise ValueError(
+                        f"Plugin list must not be empty in {file_path}"
+                    )
+                for entry in raw:
+                    if not isinstance(entry, dict):
+                        raise ValueError(
+                            f"Each item in plugin list must be a mapping in {file_path}"
+                        )
+                    self._process_plugin_entry(
+                        entry, file_path, plugin_urls, plugins
+                    )
+            elif isinstance(raw, dict):
+                self._process_plugin_entry(
+                    raw, file_path, plugin_urls, plugins
+                )
+            else:
                 raise ValueError(f"Invalid plugin config in {file_path}")
 
-            normalized_url = self._normalize_url(plugin["url"])
-
-            if normalized_url in plugin_urls:
-                raise ValueError(
-                    f"Duplicate plugin URL detected for repository '{normalized_url}' (in {file_path})"
-                )
-
-            plugin_urls.add(normalized_url)
-            plugin["url"] = normalized_url
-            plugins.append(plugin)
-
         return plugins
+
+    def _process_plugin_entry(
+        self,
+        raw: dict[str, Any],
+        file_path: str,
+        plugin_urls: set[str],
+        plugins: list[dict[str, Any]],
+    ) -> None:
+        plugin = self._build_plugin_config(raw)
+
+        if not self._is_valid_plugin(plugin):
+            raise ValueError(f"Invalid plugin config in {file_path}")
+
+        normalized_url = self._normalize_url(plugin["url"])
+
+        if normalized_url in plugin_urls:
+            raise ValueError(
+                f"Duplicate plugin URL detected for repository '{normalized_url}' (in {file_path})"
+            )
+
+        plugin_urls.add(normalized_url)
+        plugin["url"] = normalized_url
+        plugins.append(plugin)
 
     def _build_plugin_config(self, data: dict[str, Any]) -> dict[str, Any]:
         url = (data.get("url") or "").strip()

--- a/tests/code/test_plugin_installer.py
+++ b/tests/code/test_plugin_installer.py
@@ -219,13 +219,15 @@ def test_update_lock_file_discovers_tmux_sources(
 
     installer = make_installer_with_plugins()
 
-    installer.update_lock_file([
-        {
-            "plugin": {"name": "foo", "url": "owner/repo"},
-            "used_tag": "v1.0.0",
-            "commit_hash": "abc123",
-        }
-    ])
+    installer.update_lock_file(
+        [
+            {
+                "plugin": {"name": "foo", "url": "owner/repo"},
+                "used_tag": "v1.0.0",
+                "commit_hash": "abc123",
+            }
+        ]
+    )
 
     mock_write.assert_called_once()
     written_lock = mock_write.call_args[0][0]
@@ -250,13 +252,19 @@ def test_update_lock_file_respects_explicit_source(
 ) -> None:
     installer = make_installer_with_plugins()
 
-    installer.update_lock_file([
-        {
-            "plugin": {"name": "foo", "url": "owner/repo", "source": ["plugin.tmux"]},
-            "used_tag": "v1.0.0",
-            "commit_hash": "abc123",
-        }
-    ])
+    installer.update_lock_file(
+        [
+            {
+                "plugin": {
+                    "name": "foo",
+                    "url": "owner/repo",
+                    "source": ["plugin.tmux"],
+                },
+                "used_tag": "v1.0.0",
+                "commit_hash": "abc123",
+            }
+        ]
+    )
 
     mock_walk.assert_not_called()
     written_lock = mock_write.call_args[0][0]
@@ -286,13 +294,15 @@ def test_update_lock_file_reorders_to_match_config(
     ]
     installer = PluginInstaller(config, "/plugins/dir", "/tmux.conf")
 
-    installer.update_lock_file([
-        {
-            "plugin": {"name": "charlie", "url": "owner/charlie"},
-            "used_tag": None,
-            "commit_hash": None,
-        }
-    ])
+    installer.update_lock_file(
+        [
+            {
+                "plugin": {"name": "charlie", "url": "owner/charlie"},
+                "used_tag": None,
+                "commit_hash": None,
+            }
+        ]
+    )
 
     written_lock = mock_write.call_args[0][0]
     names = [p["name"] for p in written_lock["plugins"]]
@@ -315,13 +325,15 @@ def test_update_lock_file_preserves_list_format_order(
     ]
     installer = PluginInstaller(config, "/plugins/dir", "/tmux.conf")
 
-    installer.update_lock_file([
-        {
-            "plugin": {"name": "first", "url": "owner/first"},
-            "used_tag": None,
-            "commit_hash": None,
-        }
-    ])
+    installer.update_lock_file(
+        [
+            {
+                "plugin": {"name": "first", "url": "owner/first"},
+                "used_tag": None,
+                "commit_hash": None,
+            }
+        ]
+    )
 
     written_lock = mock_write.call_args[0][0]
     names = [p["name"] for p in written_lock["plugins"]]
@@ -329,13 +341,15 @@ def test_update_lock_file_preserves_list_format_order(
 
     # Simulate second install: "first" already in lock file
     mock_read.return_value = written_lock
-    installer.update_lock_file([
-        {
-            "plugin": {"name": "third", "url": "owner/third"},
-            "used_tag": None,
-            "commit_hash": None,
-        }
-    ])
+    installer.update_lock_file(
+        [
+            {
+                "plugin": {"name": "third", "url": "owner/third"},
+                "used_tag": None,
+                "commit_hash": None,
+            }
+        ]
+    )
 
     written_lock = mock_write.call_args[0][0]
     names = [p["name"] for p in written_lock["plugins"]]
@@ -343,13 +357,15 @@ def test_update_lock_file_preserves_list_format_order(
 
     # Simulate third install
     mock_read.return_value = written_lock
-    installer.update_lock_file([
-        {
-            "plugin": {"name": "second", "url": "owner/second"},
-            "used_tag": None,
-            "commit_hash": None,
-        }
-    ])
+    installer.update_lock_file(
+        [
+            {
+                "plugin": {"name": "second", "url": "owner/second"},
+                "used_tag": None,
+                "commit_hash": None,
+            }
+        ]
+    )
 
     written_lock = mock_write.call_args[0][0]
     names = [p["name"] for p in written_lock["plugins"]]
@@ -375,13 +391,15 @@ def test_update_lock_file_keeps_unknown_plugins_at_end(
     ]
     installer = PluginInstaller(config, "/plugins/dir", "/tmux.conf")
 
-    installer.update_lock_file([
-        {
-            "plugin": {"name": "alpha", "url": "owner/alpha"},
-            "used_tag": None,
-            "commit_hash": None,
-        }
-    ])
+    installer.update_lock_file(
+        [
+            {
+                "plugin": {"name": "alpha", "url": "owner/alpha"},
+                "used_tag": None,
+                "commit_hash": None,
+            }
+        ]
+    )
 
     written_lock = mock_write.call_args[0][0]
     names = [p["name"] for p in written_lock["plugins"]]

--- a/tests/code/test_plugin_installer.py
+++ b/tests/code/test_plugin_installer.py
@@ -202,3 +202,187 @@ def test_update_lock_file(mock_read: MagicMock, mock_write: MagicMock) -> None:
     installer.update_lock_file(results)
 
     mock_write.assert_called_once()
+
+
+@patch("core.lock_file_manager.write_lock_file")
+@patch("core.lock_file_manager.read_lock_file", return_value={"plugins": []})
+@patch("os.walk")
+def test_update_lock_file_discovers_tmux_sources(
+    mock_walk: MagicMock,
+    mock_read: MagicMock,
+    mock_write: MagicMock,
+) -> None:
+    mock_walk.return_value = [
+        ("/plugins/dir/foo", [], ["init.tmux", "extra.tmux", "README.md"]),
+        ("/plugins/dir/foo/sub", [], ["nested.tmux"]),
+    ]
+
+    installer = make_installer_with_plugins()
+
+    installer.update_lock_file([
+        {
+            "plugin": {"name": "foo", "url": "owner/repo"},
+            "used_tag": "v1.0.0",
+            "commit_hash": "abc123",
+        }
+    ])
+
+    mock_write.assert_called_once()
+    written_lock = mock_write.call_args[0][0]
+    plugin = written_lock["plugins"][0]
+
+    assert sorted(plugin["source"]) == sorted(
+        [
+            "/plugins/dir/foo/init.tmux",
+            "/plugins/dir/foo/extra.tmux",
+            "/plugins/dir/foo/sub/nested.tmux",
+        ]
+    )
+
+
+@patch("core.lock_file_manager.write_lock_file")
+@patch("core.lock_file_manager.read_lock_file", return_value={"plugins": []})
+@patch("os.walk")
+def test_update_lock_file_respects_explicit_source(
+    mock_walk: MagicMock,
+    mock_read: MagicMock,
+    mock_write: MagicMock,
+) -> None:
+    installer = make_installer_with_plugins()
+
+    installer.update_lock_file([
+        {
+            "plugin": {"name": "foo", "url": "owner/repo", "source": ["plugin.tmux"]},
+            "used_tag": "v1.0.0",
+            "commit_hash": "abc123",
+        }
+    ])
+
+    mock_walk.assert_not_called()
+    written_lock = mock_write.call_args[0][0]
+    plugin = written_lock["plugins"][0]
+    assert plugin["source"] == ["/plugins/dir/foo/plugin.tmux"]
+
+
+@patch("core.lock_file_manager.write_lock_file")
+@patch(
+    "core.lock_file_manager.read_lock_file",
+    return_value={
+        "plugins": [
+            {"name": "charlie", "enabled": True},
+            {"name": "alpha", "enabled": True},
+            {"name": "bravo", "enabled": True},
+        ]
+    },
+)
+def test_update_lock_file_reorders_to_match_config(
+    mock_read: MagicMock,
+    mock_write: MagicMock,
+) -> None:
+    config = [
+        {"name": "alpha", "url": "owner/alpha"},
+        {"name": "bravo", "url": "owner/bravo"},
+        {"name": "charlie", "url": "owner/charlie"},
+    ]
+    installer = PluginInstaller(config, "/plugins/dir", "/tmux.conf")
+
+    installer.update_lock_file([
+        {
+            "plugin": {"name": "charlie", "url": "owner/charlie"},
+            "used_tag": None,
+            "commit_hash": None,
+        }
+    ])
+
+    written_lock = mock_write.call_args[0][0]
+    names = [p["name"] for p in written_lock["plugins"]]
+    assert names == ["alpha", "bravo", "charlie"]
+
+
+@patch("core.lock_file_manager.write_lock_file")
+@patch(
+    "core.lock_file_manager.read_lock_file",
+    return_value={"plugins": []},
+)
+def test_update_lock_file_preserves_list_format_order(
+    mock_read: MagicMock,
+    mock_write: MagicMock,
+) -> None:
+    config = [
+        {"name": "third", "url": "owner/third"},
+        {"name": "first", "url": "owner/first"},
+        {"name": "second", "url": "owner/second"},
+    ]
+    installer = PluginInstaller(config, "/plugins/dir", "/tmux.conf")
+
+    installer.update_lock_file([
+        {
+            "plugin": {"name": "first", "url": "owner/first"},
+            "used_tag": None,
+            "commit_hash": None,
+        }
+    ])
+
+    written_lock = mock_write.call_args[0][0]
+    names = [p["name"] for p in written_lock["plugins"]]
+    assert names == ["first"]
+
+    # Simulate second install: "first" already in lock file
+    mock_read.return_value = written_lock
+    installer.update_lock_file([
+        {
+            "plugin": {"name": "third", "url": "owner/third"},
+            "used_tag": None,
+            "commit_hash": None,
+        }
+    ])
+
+    written_lock = mock_write.call_args[0][0]
+    names = [p["name"] for p in written_lock["plugins"]]
+    assert names == ["third", "first"]
+
+    # Simulate third install
+    mock_read.return_value = written_lock
+    installer.update_lock_file([
+        {
+            "plugin": {"name": "second", "url": "owner/second"},
+            "used_tag": None,
+            "commit_hash": None,
+        }
+    ])
+
+    written_lock = mock_write.call_args[0][0]
+    names = [p["name"] for p in written_lock["plugins"]]
+    assert names == ["third", "first", "second"]
+
+
+@patch("core.lock_file_manager.write_lock_file")
+@patch(
+    "core.lock_file_manager.read_lock_file",
+    return_value={
+        "plugins": [
+            {"name": "extra", "enabled": True},
+        ]
+    },
+)
+def test_update_lock_file_keeps_unknown_plugins_at_end(
+    mock_read: MagicMock,
+    mock_write: MagicMock,
+) -> None:
+    config = [
+        {"name": "alpha", "url": "owner/alpha"},
+        {"name": "bravo", "url": "owner/bravo"},
+    ]
+    installer = PluginInstaller(config, "/plugins/dir", "/tmux.conf")
+
+    installer.update_lock_file([
+        {
+            "plugin": {"name": "alpha", "url": "owner/alpha"},
+            "used_tag": None,
+            "commit_hash": None,
+        }
+    ])
+
+    written_lock = mock_write.call_args[0][0]
+    names = [p["name"] for p in written_lock["plugins"]]
+    assert names == ["alpha", "extra"]

--- a/tests/code/test_plugin_loader.py
+++ b/tests/code/test_plugin_loader.py
@@ -192,3 +192,139 @@ def test_plugin_name_derived_from_url(tmp_path: Path) -> None:
     plugin = loader.load_plugins()[0]
 
     assert plugin["name"] == "my-plugin"
+
+
+def test_load_plugins_list_format_multiple_plugins(tmp_path: Path) -> None:
+    yaml_content = """
+- url: owner/plugin-b
+- url: owner/plugin-c
+  tag: v1.0
+"""
+    (tmp_path / "plugins.yaml").write_text(yaml_content)
+
+    loader = PluginLoader(str(tmp_path))
+    plugins = loader.load_plugins()
+
+    assert len(plugins) == 2
+    assert plugins[0]["name"] == "plugin-b"
+    assert plugins[0]["url"] == "owner/plugin-b"
+    assert plugins[1]["name"] == "plugin-c"
+    assert plugins[1]["tag"] == "v1.0"
+
+
+def test_load_plugins_list_format_full_config(tmp_path: Path) -> None:
+    yaml_content = """
+- name: custom-name
+  url: owner/repo
+  local: true
+  source:
+    - main.tmux
+  tag: v2.0
+  skip_auto_update: true
+"""
+    (tmp_path / "plugins.yaml").write_text(yaml_content)
+
+    loader = PluginLoader(str(tmp_path))
+    plugins = loader.load_plugins()
+
+    assert len(plugins) == 1
+    assert plugins[0] == {
+        "name": "custom-name",
+        "url": "owner/repo",
+        "local": True,
+        "source": ["main.tmux"],
+        "tag": "v2.0",
+        "skip_auto_update": True,
+    }
+
+
+def test_load_plugins_hybrid_single_and_list_files(tmp_path: Path) -> None:
+    (tmp_path / "a-reset.yaml").write_text("url: owner/tmux-reset")
+    list_yaml = """
+- url: owner/plugin-a
+- url: owner/plugin-b
+"""
+    (tmp_path / "b-batch.yaml").write_text(list_yaml)
+    (tmp_path / "c-last.yaml").write_text("url: owner/plugin-last")
+
+    loader = PluginLoader(str(tmp_path))
+    plugins = loader.load_plugins()
+
+    names = [p["name"] for p in plugins]
+    assert "tmux-reset" in names
+    assert "plugin-a" in names
+    assert "plugin-b" in names
+    assert "plugin-last" in names
+
+
+def test_load_plugins_list_format_duplicate_within_list_raises(tmp_path: Path) -> None:
+    yaml_content = """
+- url: owner/repo
+- url: owner/repo
+"""
+    (tmp_path / "plugins.yaml").write_text(yaml_content)
+
+    loader = PluginLoader(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Duplicate plugin URL"):
+        loader.load_plugins()
+
+
+def test_load_plugins_list_format_duplicate_across_files_raises(tmp_path: Path) -> None:
+    (tmp_path / "a.yaml").write_text("url: owner/repo")
+    list_yaml = """
+- url: owner/repo
+"""
+    (tmp_path / "b.yaml").write_text(list_yaml)
+
+    loader = PluginLoader(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Duplicate plugin URL"):
+        loader.load_plugins()
+
+
+def test_load_plugins_list_format_empty_list_raises(tmp_path: Path) -> None:
+    (tmp_path / "plugins.yaml").write_text("[]")
+
+    loader = PluginLoader(str(tmp_path))
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        loader.load_plugins()
+
+
+def test_load_plugins_list_format_entry_not_a_dict_raises(tmp_path: Path) -> None:
+    yaml_content = """
+- "just-a-string"
+"""
+    (tmp_path / "plugins.yaml").write_text(yaml_content)
+
+    loader = PluginLoader(str(tmp_path))
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        loader.load_plugins()
+
+
+def test_load_plugins_list_format_entry_missing_url_raises(tmp_path: Path) -> None:
+    yaml_content = """
+- name: no-url-plugin
+"""
+    (tmp_path / "plugins.yaml").write_text(yaml_content)
+
+    loader = PluginLoader(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Invalid plugin config"):
+        loader.load_plugins()
+
+
+def test_load_plugins_list_format_preserves_order(tmp_path: Path) -> None:
+    yaml_content = """
+- url: owner/third
+- url: owner/first
+- url: owner/second
+"""
+    (tmp_path / "plugins.yaml").write_text(yaml_content)
+
+    loader = PluginLoader(str(tmp_path))
+    plugins = loader.load_plugins()
+
+    assert [p["name"] for p in plugins] == ["third", "first", "second"]


### PR DESCRIPTION
Fixes: https://github.com/PraaneshSelvaraj/coffee.tmux/issues/8

### Solution

Added in the simplest possible form:

- If the yaml file has only field, it corresponds to a single plugin => current behavior.
- In the yaml file has a list, each list item corresponds to a plugin. i.e:

```yaml
- name: custom-name
  url: owner/repo
  local: true
  source:
    - main.tmux
  tag: v2.0
  skip_auto_update: true
  
- name: custom-name-2
  url: owner/repo-2
  local: true
  source:
    - main-2.tmux
  tag: v2.0
  skip_auto_update: true
```

### Changes 
- The changes are minimal and self-contained in `plugin_loader.py`. Other files act over the `.lock` file, so no need any change.
- It just add the capability of reading lists, and abstracts the action of processing the plugin into a new method: `_process_plugin_entry()`
- Added tests and (also tested manually in my environment: https://github.com/lemunozm/dotfiles/commit/4afe91dfc4fad590e088d97b08fa1abcf2a5ca5d)